### PR TITLE
Fix: avoid hardcoding putchar ABI in example code

### DIFF
--- a/example/bf_compiler.c
+++ b/example/bf_compiler.c
@@ -76,7 +76,7 @@ x64Ins* bf_compile(char* in) {
 			rax_garbled = true;
 			vpusharr(ret, {
 				{ MOV, rax, mem($rbp, -8) },
-				{ MOV, rcx, mem($rax) },
+				{ MOV, arg1, mem($rax) },
 				{ SUB, rsp, imm(64) }, // Should investigate aligining the stack to 16 bytes but this works for now(what msvc does).
 				{ MOV, rax, imptr(putchar) },
 				{ CALL, rax },


### PR DESCRIPTION
The `bf_compiler.c` example creates a platform-dependent variable which describes the calling convention, but it is still hard coded in the `.` instruction where it should supply an argument. This makes the code work incorrectly according to the System-V ABI.

This simple change fixes the broken example code.