### PR TITLE
Fix: always pop return address in example code

### DIFF
--- a/example/bf_compiler.c
+++ b/example/bf_compiler.c
@@ -88,8 +88,8 @@ x64Ins* bf_compile(char* in) {
 			vpusharr(ret, {
 				{ MOV, rax, mem($rbp, -8) },
 				{ CMP, m8($rax), imm(0) },
-				{ JZ, rel(3) },
 				{ POP, rax },
+				{ JZ, rel(2) },
 				{ JMP, rax },
 			});
 		default: break;


### PR DESCRIPTION
The `bf_compiler.c` example originally only popped the return address when exiting the loop, which causes the stack depth to not be conserved, accumulating each time the loop is run. This bug can cause stack overflows and affects the behavior of nested loops.
Instead, we can just always pop the return address, because it will be pushed again when jumping back.